### PR TITLE
Accessibility Change

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -24,6 +24,9 @@
 				"name": "Card height",
 				"hint": "How tall in pixels cards in the hand/deck/pile should be displayed."
 			}
+		},
+		"aria": {
+			"playCard": "{name}, Play"
 		}
 	}
 }

--- a/templates/monarch-hand.hbs
+++ b/templates/monarch-hand.hbs
@@ -23,7 +23,7 @@
 							</section>
 							<div class="card-controls">
 								{{#if @root.editable}}
-									<a class="card-control" title="{{localize 'CARD.Play'}}" data-action="play"><i
+									<a class="card-control" tabindex="0" title="{{localize 'CARD.Play'}}" data-action="play" aria-label="{{card.name}}, Play"><i
 											class="fas fa-chevron-circle-right"></i></a>
 								{{/if}}
 							</div>

--- a/templates/monarch-hand.hbs
+++ b/templates/monarch-hand.hbs
@@ -23,9 +23,13 @@
 							</section>
 							<div class="card-controls">
 								{{#if @root.editable}}
-									<a class="card-control" tabindex="0" title="{{localize 'CARD.Play'}}" data-action="play" 
-										aria-label="{{card.name}}, {{localize 'CARD.Play'}}">
-										<i class="fas fa-chevron-circle-right"></i></a>
+									<a class="card-control" 
+										tabindex="0" 
+										title="{{localize 'CARD.Play'}}" 
+										data-action="play" 
+										aria-label="{{localize "monarch.aria.playCard" name=card.name}}">
+										<i class="fas fa-chevron-circle-right"></i>
+									</a>
 								{{/if}}
 							</div>
 						</section>

--- a/templates/monarch-hand.hbs
+++ b/templates/monarch-hand.hbs
@@ -23,8 +23,9 @@
 							</section>
 							<div class="card-controls">
 								{{#if @root.editable}}
-									<a class="card-control" tabindex="0" title="{{localize 'CARD.Play'}}" data-action="play" aria-label="{{card.name}}, Play"><i
-											class="fas fa-chevron-circle-right"></i></a>
+									<a class="card-control" tabindex="0" title="{{localize 'CARD.Play'}}" data-action="play" 
+										aria-label="{{card.name}}, {{localize 'CARD.Play'}}">
+										<i class="fas fa-chevron-circle-right"></i></a>
 								{{/if}}
 							</div>
 						</section>

--- a/templates/monarch-pile.hbs
+++ b/templates/monarch-pile.hbs
@@ -32,8 +32,13 @@
 						</div>
 						<div class="card-controls">
 							{{#if @root.editable}}
-								<a class="card-control" title="{{localize 'CARD.Play'}}" data-action="play"><i
-										class="fas fa-chevron-circle-right"></i></a>
+								<a class="card-control" 
+									tabindex="0" 
+									title="{{localize 'CARD.Play'}}" 
+									data-action="play" 
+									aria-label="{{localize "monarch.aria.playCard" name=card.name}}">
+									<i class="fas fa-chevron-circle-right"></i>
+								</a>
 							{{/if}}
 						</div>
 					</section>


### PR DESCRIPTION
I thiiiiink this should introduce a very rudimentary accessibility for blind players to use Monarch. Adds each card's Play button to the tab index, allowing the player to tab through their hand one at a time. Also adds an aria label that names the card and indicates that the button may be pressed to play it.